### PR TITLE
allow user feedback for regenerating scenes

### DIFF
--- a/server/src/functions/video/buildGCPVideoPrompt.ts
+++ b/server/src/functions/video/buildGCPVideoPrompt.ts
@@ -155,5 +155,12 @@ export function buildGCPVideoPrompt(data: postVideoSchemaType): string {
       `NEGATIVE CONCERNS: Avoid ${negativePrompt}`,
    );
 
+   // 8. User Revision Instructions (only present on regeneration with feedback)
+   if (data.feedback && data.feedback.trim().length > 0) {
+      sections.push(
+         `REVISION INSTRUCTIONS: The user wants these changes from the previous generation: ${data.feedback.trim()}`
+      );
+   }
+
    return sections.join('\n');
 }

--- a/shared/src/schemas/sendVideoSchema.ts
+++ b/shared/src/schemas/sendVideoSchema.ts
@@ -15,6 +15,8 @@ export const sendVideoSchema = z.object({
    // Video continuation fields
    lastFrameBase64: z.string().optional(),  // base64 PNG → image-to-video fallback (>48h)
    geminiVideoUri: z.string().optional(),   // Gemini Files API URI → native Veo extension (<48h)
+   // User feedback for regeneration
+   feedback: z.string().optional(),
 });
 
 //@ the wanted structure of data that someone POSTS:

--- a/shared/src/types/reactflow/flowTypes.ts
+++ b/shared/src/types/reactflow/flowTypes.ts
@@ -52,6 +52,8 @@ export type SceneNodeData = {
    /** Gemini Files API URI of the generated video (e.g. https://generativelanguage.googleapis.com/v1beta/files/...).
     *  Only valid for ~48h after generation. Used for native Veo video extension. */
    geminiVideoUri?: string;
+   /** User feedback / revision instructions for regeneration. */
+   feedback?: string;
 };
 export type SceneNode = Node<SceneNodeData, 'scene'>;
 

--- a/studio/src/components/reactflow/customnodes/SceneNode.tsx
+++ b/studio/src/components/reactflow/customnodes/SceneNode.tsx
@@ -15,6 +15,7 @@ import {
    Type,
    Lock,
    Layers,
+   MessageSquare,
 } from 'lucide-react';
 import { useEffect } from 'react';
 
@@ -208,6 +209,24 @@ export default function SceneNode({ data, id, selected }: NodeProps<SceneNode>) 
                   <p className="text-[10px] text-red-600 font-medium leading-relaxed">
                      {data.errorMessage}
                   </p>
+               </div>
+            )}
+
+            {/* Feedback for Regeneration — only visible when video is READY */}
+            {data.status === 'READY' && (
+               <div className="flex flex-col gap-1">
+                  <label className="text-[10px] font-bold text-purple-400 uppercase flex items-center gap-1">
+                     <MessageSquare size={10} />
+                     What should change?
+                  </label>
+                  <textarea
+                     className="w-full text-[11px] p-2 border-2 border-purple-200 rounded-lg focus:border-purple-500 outline-none transition-colors font-medium min-h-[44px] resize-none bg-purple-50/40 placeholder:text-slate-300"
+                     placeholder="e.g. Make the character smile more, zoom in closer..."
+                     value={data.feedback || ''}
+                     onChange={(e) =>
+                        updateNode(id, { feedback: e.target.value })
+                     }
+                  />
                </div>
             )}
 

--- a/studio/src/hooks/useFlowStore.ts
+++ b/studio/src/hooks/useFlowStore.ts
@@ -250,6 +250,7 @@ const useFlowStore = create<FlowState>()(
                      negativePrompt: projectState.globalNegativePrompt,
                      imageBase64: '',
                      lastFrameBase64,
+                     feedback: sceneNode.data.feedback,
                   },
                });
 


### PR DESCRIPTION
Added a section after a video has been generated where the user can provide feedback and update the generation if they want to. The feedback section is only present if the video has been generated: 

<img width="631" height="816" alt="image" src="https://github.com/user-attachments/assets/bf3b54c3-4a04-44d5-9659-5a75a9db0d34" />

vs

<img width="679" height="673" alt="image" src="https://github.com/user-attachments/assets/0328c6b6-1f29-4b65-8503-fb6649385d14" />
